### PR TITLE
feature: Track bitflags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "sunspec_rs"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c246860750964960a2cdd59bde29ae5220409ea72bcd869562fafe88b7075946"
+checksum = "1bb9376b523c614948600b3fa8120b17920f9432ef25aca30fe3b4a168657810"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.105"
 serde_yaml = "=0.8.26"
 prometheus = {version = "0.13.3", features=["process"]}
 #sunspec_rs = { path="../sunspec_rs" }
-sunspec_rs = { version = "0.10.3" }
+sunspec_rs = { version = "0.10.4" }
 console-subscriber = "0.1.10"
 chrono = "0.4.28"
 rand = "0.8.5"

--- a/migrations/20251211154408_add_bitfield_history.sql
+++ b/migrations/20251211154408_add_bitfield_history.sql
@@ -1,0 +1,6 @@
+-- Add migration script here
+CREATE TABLE IF NOT EXISTS bitfield_history (
+    uniqueid VARCHAR(255) NOT NULL,
+    field_name VARCHAR(255) NOT NULL,
+    UNIQUE(uniqueid, field_name)
+    );


### PR DESCRIPTION
This PR implements a new table in the state database that keeps track of bitfield states.  In the current version of the gateway, we only report "on" when we get a state object.  The net effect of this in home assistant is that there's constantly "Unknown" or "Unavailable" items in the lists of flags.

With the code in this PR, we will keep track intelligently by serial-modelid-point to see what values have previously been reported and will send "off" values if they are not reported as "on" by the modbus response.